### PR TITLE
Compatibility with vim-json

### DIFF
--- a/plugin/jsonld.vim
+++ b/plugin/jsonld.vim
@@ -1,0 +1,1 @@
+runtime! ftplugin/json.vim

--- a/syntax/jsonld.vim
+++ b/syntax/jsonld.vim
@@ -4,8 +4,16 @@ endif
 
 runtime! syntax/json.vim
 
-syn match jsonldKeyword '"@\w\+"'
-syn match jsonldCurie '"\w\+:\(\([^/"][^/"]\|/\?[^/"]\)[^"]*\)\?"'
+if !exists("g:vim_json_syntax_conceal")
+    syn region  jsonString oneline start=/"/  skip=/\\\\\|\\"/  end=/"/
+    syn match   jsonKeywordMatch /"[^\"\:]\+"[[:blank:]\r\n]*\:/ contains=jsonKeywordRegion
+    syn region  jsonKeywordRegion matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained
+    hi def link jsonldKeyword Keyword
+else
+    hi def link jsonldKeyword Underlined
+endif
 
-hi def link jsonldKeyword Keyword
+syn match jsonldKeyword /@\w\+/ contained containedin=jsonString,jsonKeywordRegion
+syn match jsonldCurie '\w\+:\(\([^/"][^/"]\|/\?[^/"]\)[^"]*\)\+' contained containedin=jsonString,jsonKeywordRegion
+
 hi def link jsonldCurie Special


### PR DESCRIPTION
First of all, thank you for this useful repo :+1:

I am also using [vim-json](https://github.com/elzr/vim-json), which adds concealing to json files. With this patch, both extensions play together nicely.

While I was at it, I've also modified the default behaviour slightly so that it does not highlight the enclosing quotes, only the inner key/value.
